### PR TITLE
Използване на base64url за предаване на URL във Firefox

### DIFF
--- a/common/warning.js
+++ b/common/warning.js
@@ -7,12 +7,12 @@
     return decodeURIComponent(location.href.toString().split('?')[1]);
   }
 
-  document.getElementById('current_url').innerText = getCurrentUrl();
   document.getElementById('go_back').onclick = function() {
     history.back();
   };
 
   if (firefox) {
+    document.getElementById('current_url').innerHTML = urlSafeDecode(getCurrentUrl());
     self.port.on("redirectTo", function(url) {
       location.href = url;
     });
@@ -21,6 +21,7 @@
       self.port.emit("allowCurrentUrl", getCurrentUrl());
     };
   } else {
+    document.getElementById('current_url').innerText = getCurrentUrl();
     document.getElementById('force_continue').onclick = function() {
       chrome.runtime.sendMessage({allowCurrentUrl: getCurrentUrl()});
     };

--- a/firefox/data/base64decode.js
+++ b/firefox/data/base64decode.js
@@ -1,0 +1,9 @@
+var urlSafeDecode = function(string, encoding) {
+  // Add padding
+  while (string.length % 4)
+    string += '=';
+
+  string = string.replace(/-/g, '+').replace(/_/g, '/')
+
+  return atob(string);
+};

--- a/firefox/lib/base64url.js
+++ b/firefox/lib/base64url.js
@@ -1,13 +1,13 @@
 var base64 = require("sdk/base64");
 
-urlSafeEncode = function(string, encoding) {
+var urlSafeEncode = function(string, encoding) {
   return base64.encode(string, encoding)
     .replace(/\+/g, '-')
     .replace(/\//g, '_')
     .replace(/=+$/, '');
 };
 
-urlSafeDecode = function(string, encoding) {
+var urlSafeDecode = function(string, encoding) {
   // Add padding
   while (string.length % 4)
     string += '=';

--- a/firefox/lib/base64url.js
+++ b/firefox/lib/base64url.js
@@ -1,0 +1,23 @@
+var base64 = require("sdk/base64");
+
+urlSafeEncode = function(string, encoding) {
+  return base64.encode(string, encoding)
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+};
+
+urlSafeDecode = function(string, encoding) {
+  // Add padding
+  while (string.length % 4)
+    string += '=';
+
+  string = string.replace(/-/g, '+').replace(/_/g, '/')
+
+  return base64.decode(string);
+};
+
+if (typeof exports !== 'undefined') {
+  exports.urlSafeEncode = urlSafeEncode;
+  exports.urlSafeDecode = urlSafeDecode;
+}

--- a/firefox/lib/main.js
+++ b/firefox/lib/main.js
@@ -51,7 +51,8 @@ exports.main = function() {
 
   PageMod({
     include: /resource:\/\/.*\/dancewithme\/data\/warning\.html.*/,
-    contentScriptFile: data.url('warning.js'),
+    contentScriptFile: [data.url('base64decode.js'),
+                        data.url('warning.js')],
     onAttach: function(worker) {
       worker.port.on("allowCurrentUrl", function(encodedURL) {
         var url = base64url.urlSafeDecode(encodedURL);

--- a/firefox/test/test-base64url.js
+++ b/firefox/test/test-base64url.js
@@ -1,0 +1,22 @@
+const base64url = require('./base64url');
+
+var testEncodeDecode = function(test, original, encoded) {
+  test.assertEqual(base64url.urlSafeEncode(original), encoded);
+  test.assertEqual(base64url.urlSafeDecode(encoded), original);
+}
+
+exports.testPlusSubstitution = function(test) {
+  testEncodeDecode(test, '~~~', 'fn5-');
+}
+
+exports.testSlashSubstitution = function(test) {
+  testEncodeDecode(test, 'ÿÿÿ', '____');
+}
+
+exports.testPadding = function(test) {
+  testEncodeDecode(test, 'a', 'YQ');
+}
+
+exports.testURL = function(test) {
+  testEncodeDecode(test, 'http://example.com', 'aHR0cDovL2V4YW1wbGUuY29t');
+}


### PR DESCRIPTION
Не е яко да пазим списък с всички блокирани поискани URL-и в разширението, защото усложнява излишно имплементацията (вкл. на показването на поискания адрес в `warning.html`).

Днес по случайност попаднах на [base64url](http://tools.ietf.org/html/rfc4648#section-5). Някой против да рефкторирам Firefox версията да го използва?
