### PR TITLE
Добавяне на "novinite.com" в списъка с блокирани домейни

### DIFF
--- a/common/blocked_domains.js
+++ b/common/blocked_domains.js
@@ -35,7 +35,8 @@ function checkForPeevskiDomain(url) {
     'radiovitosha.com',
     'radioveselina.bg',
     'magicfm.bg',
-    'thevoice.bg'
+    'thevoice.bg',
+    'novinite.com'
   ];
 
   for (var i = 0; i < blockedDomains.length; i++) {

--- a/common/blocked_domains.js
+++ b/common/blocked_domains.js
@@ -36,7 +36,9 @@ function checkForPeevskiDomain(url) {
     'radioveselina.bg',
     'magicfm.bg',
     'thevoice.bg',
-    'novinite.com'
+    'novinite.com',
+    'novinite.bg',
+    'novinite.ru'
   ];
 
   for (var i = 0; i < blockedDomains.length; i++) {


### PR DESCRIPTION
Атанас Чобанов е [публикувал](http://goo.gl/2ffv3d) документ, според който КТБ е свързана чрез кредит за 1млн. евро с фирма (Тетрареал АД), която държи половината от капитала на Новините АД - дружеството, което стопанисва "novinite.com". Ако този документ е автентичен, можем да считаме този новинарски сайт за част от групата на Делян Пеевски.

С този pull request добавям сайта към списъка на разпознаваните от приставката.
